### PR TITLE
Add manual trigger and permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -48,3 +48,21 @@ jobs:
       with:
         name: release-apk
         path: app/build/outputs/apk/release/app-release.apk
+
+    - name: Decode Keystore
+      env:
+        ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_FILE_BASE64 }}
+      run: |
+        mkdir -p ./keystore/keystore_new
+        echo $ENCODED_KEYSTORE | base64 --decode > ./keystore/keystore_new/screentouchlocker.jks
+
+    - name: Create keystore.properties
+      env:
+        KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+        KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+        KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+      run: |
+        echo "storeFile=./keystore/keystore_new/screentouchlocker.jks" > ./keystore/keystore_new/keystore_pkcs12.properties
+        echo "keyAlias=$KEYSTORE_KEY_ALIAS" >> ./keystore/keystore_new/keystore_pkcs12.properties
+        echo "keyPassword=$KEYSTORE_KEY_PASSWORD" >> ./keystore/keystore_new/keystore_pkcs12.properties
+        echo "storePassword=$KEYSTORE_STORE_PASSWORD" >> ./keystore/keystore_new/keystore_pkcs12.properties

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,7 +44,7 @@ jobs:
       run: ./gradlew assembleRelease
 
     - name: Upload Release APK
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-apk
         path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,7 +44,7 @@ jobs:
       run: ./gradlew assembleRelease
 
     - name: Upload Release APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-apk
         path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,25 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: gradle
-        
+
+    - name: Decode Keystore
+      env:
+        ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_FILE_BASE64 }}
+      run: |
+        mkdir -p ./keystore/keystore_new
+        echo $ENCODED_KEYSTORE | base64 --decode > ./keystore/keystore_new/screentouchlocker.jks
+
+    - name: Create keystore.properties
+      env:
+        KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+        KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+        KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+      run: |
+        echo "storeFile=./keystore/keystore_new/screentouchlocker.jks" > ./keystore/keystore_new/keystore_pkcs12.properties
+        echo "keyAlias=$KEYSTORE_KEY_ALIAS" >> ./keystore/keystore_new/keystore_pkcs12.properties
+        echo "keyPassword=$KEYSTORE_KEY_PASSWORD" >> ./keystore/keystore_new/keystore_pkcs12.properties
+        echo "storePassword=$KEYSTORE_STORE_PASSWORD" >> ./keystore/keystore_new/keystore_pkcs12.properties
+
     - name: Run ktlint
       run: ./gradlew spotlessCheck
 
@@ -48,21 +66,3 @@ jobs:
       with:
         name: release-apk
         path: app/build/outputs/apk/release/app-release.apk
-
-    - name: Decode Keystore
-      env:
-        ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_FILE_BASE64 }}
-      run: |
-        mkdir -p ./keystore/keystore_new
-        echo $ENCODED_KEYSTORE | base64 --decode > ./keystore/keystore_new/screentouchlocker.jks
-
-    - name: Create keystore.properties
-      env:
-        KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
-        KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
-        KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
-      run: |
-        echo "storeFile=./keystore/keystore_new/screentouchlocker.jks" > ./keystore/keystore_new/keystore_pkcs12.properties
-        echo "keyAlias=$KEYSTORE_KEY_ALIAS" >> ./keystore/keystore_new/keystore_pkcs12.properties
-        echo "keyPassword=$KEYSTORE_KEY_PASSWORD" >> ./keystore/keystore_new/keystore_pkcs12.properties
-        echo "storePassword=$KEYSTORE_STORE_PASSWORD" >> ./keystore/keystore_new/keystore_pkcs12.properties

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,6 +32,9 @@ jobs:
         mkdir -p ./keystore/keystore_new
         echo $ENCODED_KEYSTORE | base64 --decode > ./keystore/keystore_new/screentouchlocker.jks
 
+    - name: Check ENCODED_KEYSTORE value
+      run: echo $ENCODED_KEYSTORE
+
     - name: Create keystore.properties
       env:
         KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build:

--- a/keystore/keystore_new/keystore_pkcs12.properties
+++ b/keystore/keystore_new/keystore_pkcs12.properties
@@ -1,0 +1,4 @@
+storeFile=./keystore/keystore_new/screentouchlocker.jks
+keyAlias=${{ secrets.KEYSTORE_KEY_ALIAS }}
+keyPassword=${{ secrets.KEYSTORE_KEY_PASSWORD }}
+storePassword=${{ secrets.KEYSTORE_STORE_PASSWORD }}


### PR DESCRIPTION
* Add `workflow_dispatch:` to the `on` section to allow manual triggering of the workflow
* Add `permissions` section with `contents: read` and `packages: write` to control access levels for the workflow