### PR TITLE
Fix keystore file not found issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.toptal.com/developers/gitignore/api/androidstudio,kotlin,android
 # Edit at https://www.toptal.com/developers/gitignore?templates=androidstudio,kotlin,android
 
@@ -31,6 +30,7 @@ render.experimental.xml
 /keystore
 *.jks
 *.keystore
+!keystore/keystore_new/screentouchlocker.jks
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+!keystore/keystore_new/screentouchlocker.jks


### PR DESCRIPTION
Add an exception for the keystore file in `.gitignore`.

* Add `!keystore/keystore_new/screentouchlocker.jks` under the "Keystore files" section to track the keystore file. 

